### PR TITLE
Feature 10 forecast webhook endpoint

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -270,14 +270,14 @@ paths:
         - name: before
           required: false
           in: query
-          description: Last day that timeEntrys will be included format yyyy-mm-dd
+          description: Retrieve time entries before given date.
           schema:
             type: string
             format: date
         - name: after
           required: false
           in: query
-          description: First day that timeEntrys will be included format yyyy-mm-dd
+          description: Retrieve time entries after given date.
           schema:
             type: string
             format: date

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -6,14 +6,14 @@ info:
 
 security:
   - bearerAuth: []
-  
+
 paths:
   /v1/system/ping:
     get:
       operationId: ping
       summary: Replies with pong
       description: Replies ping with pong
-      tags: 
+      tags:
         - System
       responses:
         "200":
@@ -22,13 +22,13 @@ paths:
             text/plain:
               schema:
                 type: string
-                
+
   /v1/persons:
     get:
       operationId: listPersons
       summary: Get list of Timebank persons.
       description: Get list of Timebank persons.
-      tags: 
+      tags:
         - Persons
       parameters:
         - name: active
@@ -51,7 +51,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-  
+
   /v1/persons/{personId}:
     put:
       operationId: updatePerson
@@ -80,7 +80,7 @@ paths:
           content:
             application/json:
               schema:
-                  $ref: '#/components/schemas/Person'
+                $ref: '#/components/schemas/Person'
         "default":
           description: Invalid request was sent to the server.
           content:
@@ -246,7 +246,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-        
+
   /v1/persons/{personId}/total:
     get:
       operationId: listPersonTotalTime
@@ -267,6 +267,20 @@ paths:
           description: Default value is ALL_TIME.
           schema:
             $ref: "#/components/schemas/Timespan"
+        - name: before
+          required: false
+          in: query
+          description: Last day that timeEntrys will be included format yyyy-mm-dd
+          schema:
+            type: string
+            format: date
+        - name: after
+          required: false
+          in: query
+          description: First day that timeEntrys will be included format yyyy-mm-dd
+          schema:
+            type: string
+            format: date
       responses:
         "200":
           description: |-
@@ -294,7 +308,7 @@ components:
       type: http
       scheme: bearer
       bearerFormat: JWT
-      
+
   schemas:
 
     Error:
@@ -311,16 +325,16 @@ components:
         message:
           type: string
           description: Error message
-          
+
     Timespan:
       type: string
       description: Enum for timespan
-      enum: 
+      enum:
         - ALL_TIME
         - YEAR
         - MONTH
         - WEEK
-          
+
     Person:
       type: object
       description: Person Data from Forecast API

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -215,27 +215,27 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
-  /v1/ForecastTimeEntriesDeleteWebhook:
+  /v1/forecastWebhook:
     post:
-      operationId: ForecastTimeEntriesDeleteWebhook
+      operationId: forecastWebhook
       summary: Handle deleted time entries from Forecast API
-      description: This endpoint handles webhook notifications from Forecast.it API when a time entry is deleted. It extracts the ID of the deleted time entry and deletes the corresponding entry in Timebank
+      description: This endpoint handles webhook notifications from Forecast.it API
       tags:
-        - TimeEntries
+        - ForecastWebhook
       parameters:
         - in: query
-          name: forecastDeleteWebhookKey
+          name: forecastWebhookKey
           required: false
           schema:
             type: string
-          description: key
+          description: key to verify origin of request
       requestBody:
-        description: Deleted time entry from Forecast will be deleted from time bank
+        description: Webhook content
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ForecastDeleteWebhookEvent'
+              $ref: '#/components/schemas/ForecastWebhookEvent'
       responses:
         '200':
           description: Webhook notification processed successfully.
@@ -269,41 +269,16 @@ paths:
           schema:
             type: string
             format: date
+        - name: syncDeleted
+          required: false
+          in: query
+          description: Synchronizes deleted time entries
+          schema:
+            type: boolean
+            default: false
       responses:
         "204":
           description: Synchronized time entries from Forecast API.
-        "default":
-          description: Invalid request was sent to the server.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-
-  /v1/synchronizeDeletions:
-    post:
-      operationId: synchronizeDeletedTimeEntries
-      summary: Synchronizes time entries from Forecast API and Time bank API.
-      description: Synchronizes time entries from Forecast API and Time bank API.
-      tags:
-        - Synchronize
-      parameters:
-        - name: before
-          required: false
-          in: query
-          description: Retrieve time entries before given date.
-          schema:
-            type: string
-            format: date
-        - name: after
-          required: false
-          in: query
-          description: Retrieve time entries after given date.
-          schema:
-            type: string
-            format: date
-      responses:
-        "204":
-          description: Synchronizes time entries from Forecast API and Time bank API.
         "default":
           description: Invalid request was sent to the server.
           content:
@@ -639,7 +614,7 @@ components:
           type: boolean
           description: Is time entry vacation or not
 
-    ForecastDeleteWebhookEvent:
+    ForecastWebhookEvent:
       type: object
       properties:
         timestamp:
@@ -651,11 +626,11 @@ components:
           example: task_deleted
           description: String. A string consisting of the type of object and the type of event.
         object:
-          $ref: '#/components/schemas/ForecastDeleteWebhookObject'
+          $ref: '#/components/schemas/ForecastWebhookObject'
         person:
-          $ref: '#/components/schemas/ForecastDeleteWebhookPerson'
+          $ref: '#/components/schemas/ForecastWebhookPerson'
 
-    ForecastDeleteWebhookObject:
+    ForecastWebhookObject:
       type: object
       required:
         - id
@@ -666,7 +641,7 @@ components:
           example: 1
           description: Integer. The id of the object in question.
 
-    ForecastDeleteWebhookPerson:
+    ForecastWebhookPerson:
       type: object
       properties:
         id:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -287,13 +287,6 @@ paths:
       tags:
         - Synchronize
       parameters:
-        - name: personId
-          required: false
-          in: query
-          description: Filter by persons unique ID
-          schema:
-            type: integer
-            format: int32
         - name: before
           required: false
           in: query
@@ -308,12 +301,6 @@ paths:
           schema:
             type: string
             format: date
-        - name: vacation
-          required: false
-          in: query
-          description: Filter vacations
-          schema:
-            type: boolean
       responses:
         "204":
           description: Synchronizes time entries from Forecast API and Time bank API.

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -222,6 +222,13 @@ paths:
       description: This endpoint handles webhook notifications from Forecast.it API when a time entry is deleted. It extracts the ID of the deleted time entry and deletes the corresponding entry in Timebank
       tags:
         - TimeEntries
+      parameters:
+        - in: query
+          name: forecastDeleteWebhookKey
+          required: false
+          schema:
+            type: string
+          description: key
       requestBody:
         description: Deleted time entry from Forecast will be deleted from time bank
         required: true

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -223,12 +223,12 @@ paths:
       tags:
         - TimeEntries
       requestBody:
-        description: Optional description in *Markdown*
+        description: Deleted time entry from
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TimeEntryDeletedEvent'
+              $ref: '#/components/schemas/WebhookEvent'
       responses:
         '200':
           description: Webhook notification processed successfully.
@@ -238,6 +238,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+
 
   /v1/synchronize:
     post:
@@ -294,14 +295,14 @@ paths:
         - name: before
           required: false
           in: query
-          description: Retrieve time entries before given date.
+          description: Last day that timeEntrys will be included format yyyy-mm-dd
           schema:
             type: string
             format: date
         - name: after
           required: false
           in: query
-          description: Retrieve time entries after given date.
+          description: First day that timeEntrys will be included format yyyy-mm-dd
           schema:
             type: string
             format: date
@@ -599,29 +600,36 @@ components:
           type: boolean
           description: Is time entry vacation or not
 
-    TimeEntryDeletedEvent:
+    WebhookEvent:
       type: object
-      description: Person's single time entry
+      properties:
+        timestamp:
+          type: string
+          example: 2021-09-23T07:30:00Z
+          description: String. A UTC timestamp of when the event happened
+        event:
+          type: string
+          example: task_updated
+          description: String. A string consisting of the type of object and the type of event.
+        object:
+          $ref: '#/components/schemas/WebhookObject'
+        person:
+          $ref: '#/components/schemas/WebhookPerson'
+    WebhookObject:
+      type: object
       required:
         - id
-        - deleted_at
-        - project_id
-        - task_id
-        - resource_id
-        - hours
-        - description
       properties:
         id:
           type: integer
-        deleted_at:
-          type: string
-        project_id:
+          format: int32
+          example: 1
+          description: Integer. The id of the object in question.
+    WebhookPerson:
+      type: object
+      properties:
+        id:
           type: integer
-        task_id:
-          type: integer
-        resource_id:
-          type: integer
-        hours:
-          type: integer
-        description:
-          type: string
+          format: int32
+          example: 1
+          description: Integer. The id of the person who triggered the event in Forecast

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -225,10 +225,10 @@ paths:
       parameters:
         - in: query
           name: forecastWebhookKey
-          required: false
+          required: true
           schema:
             type: string
-          description: key to verify origin of request
+          description: key to authenticate incoming webhooks
       requestBody:
         description: Webhook content
         required: true
@@ -237,7 +237,7 @@ paths:
             schema:
               $ref: '#/components/schemas/ForecastWebhookEvent'
       responses:
-        '200':
+        '204':
           description: Webhook notification processed successfully.
         "default":
           description: Invalid request was sent to the server.
@@ -270,7 +270,7 @@ paths:
             type: string
             format: date
         - name: syncDeleted
-          required: false
+          required: true
           in: query
           description: Synchronizes deleted time entries
           schema:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -215,20 +215,20 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
-  /v1/timeEntriesDelete/webhook:
+  /v1/ForecastTimeEntriesDeleteWebhook:
     post:
-      operationId: TimeEntriesDeleteWebhook
+      operationId: ForecastTimeEntriesDeleteWebhook
       summary: Handle deleted time entries from Forecast API
       description: This endpoint handles webhook notifications from Forecast.it API when a time entry is deleted. It extracts the ID of the deleted time entry and deletes the corresponding entry in Timebank
       tags:
         - TimeEntries
       requestBody:
-        description: Deleted time entry from
+        description: Deleted time entry from Forecast will be deleted from time bank
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/WebhookEvent'
+              $ref: '#/components/schemas/ForecastDeleteWebhookEvent'
       responses:
         '200':
           description: Webhook notification processed successfully.
@@ -600,7 +600,7 @@ components:
           type: boolean
           description: Is time entry vacation or not
 
-    WebhookEvent:
+    ForecastDeleteWebhookEvent:
       type: object
       properties:
         timestamp:
@@ -609,13 +609,14 @@ components:
           description: String. A UTC timestamp of when the event happened
         event:
           type: string
-          example: task_updated
+          example: task_deleted
           description: String. A string consisting of the type of object and the type of event.
         object:
-          $ref: '#/components/schemas/WebhookObject'
+          $ref: '#/components/schemas/ForecastDeleteWebhookObject'
         person:
-          $ref: '#/components/schemas/WebhookPerson'
-    WebhookObject:
+          $ref: '#/components/schemas/ForecastDeleteWebhookPerson'
+
+    ForecastDeleteWebhookObject:
       type: object
       required:
         - id
@@ -625,7 +626,8 @@ components:
           format: int32
           example: 1
           description: Integer. The id of the object in question.
-    WebhookPerson:
+          
+    ForecastDeleteWebhookPerson:
       type: object
       properties:
         id:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -215,6 +215,30 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
+  /v1/timeEntriesDelete/webhook:
+    post:
+      operationId: TimeEntriesDeleteWebhook
+      summary: Handle deleted time entries from Forecast API
+      description: This endpoint handles webhook notifications from Forecast.it API when a time entry is deleted. It extracts the ID of the deleted time entry and deletes the corresponding entry in Timebank
+      tags:
+        - TimeEntries
+      requestBody:
+        description: Optional description in *Markdown*
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TimeEntryDeletedEvent'
+      responses:
+        '200':
+          description: Webhook notification processed successfully.
+        "default":
+          description: Invalid request was sent to the server.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
   /v1/synchronize:
     post:
       operationId: synchronizeTimeEntries
@@ -574,3 +598,30 @@ components:
         isVacation:
           type: boolean
           description: Is time entry vacation or not
+
+    TimeEntryDeletedEvent:
+      type: object
+      description: Person's single time entry
+      required:
+        - id
+        - deleted_at
+        - project_id
+        - task_id
+        - resource_id
+        - hours
+        - description
+      properties:
+        id:
+          type: integer
+        deleted_at:
+          type: string
+        project_id:
+          type: integer
+        task_id:
+          type: integer
+        resource_id:
+          type: integer
+        hours:
+          type: integer
+        description:
+          type: string

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -216,7 +216,7 @@ paths:
                 $ref: "#/components/schemas/Error"
 
   /v1/forecastWebhook:
-    delete:
+    post:
       operationId: forecastWebhook
       summary: Handle deleted time entries from Forecast API
       description: This endpoint handles webhook notifications from Forecast.it API

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -216,7 +216,7 @@ paths:
                 $ref: "#/components/schemas/Error"
 
   /v1/forecastWebhook:
-    post:
+    delete:
       operationId: forecastWebhook
       summary: Handle deleted time entries from Forecast API
       description: This endpoint handles webhook notifications from Forecast.it API

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -222,6 +222,13 @@ paths:
       description: This endpoint handles webhook notifications from Forecast.it API when a time entry is deleted. It extracts the ID of the deleted time entry and deletes the corresponding entry in Timebank
       tags:
         - TimeEntries
+      parameters:
+        - name: "X-FORECAST-API-KEY"
+          in: "header"
+          description: "The secret used to authenticate the request"
+          required: true
+          schema:
+            type: string
       requestBody:
         description: Deleted time entry from Forecast will be deleted from time bank
         required: true
@@ -626,7 +633,7 @@ components:
           format: int32
           example: 1
           description: Integer. The id of the object in question.
-          
+
     ForecastDeleteWebhookPerson:
       type: object
       properties:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -222,13 +222,6 @@ paths:
       description: This endpoint handles webhook notifications from Forecast.it API when a time entry is deleted. It extracts the ID of the deleted time entry and deletes the corresponding entry in Timebank
       tags:
         - TimeEntries
-      parameters:
-        - name: "X-FORECAST-API-KEY"
-          in: "header"
-          description: "The secret used to authenticate the request"
-          required: true
-          schema:
-            type: string
       requestBody:
         description: Deleted time entry from Forecast will be deleted from time bank
         required: true
@@ -279,6 +272,51 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
+  /v1/synchronizeDeletions:
+    post:
+      operationId: synchronizeDeletedTimeEntries
+      summary: Synchronizes time entries from Forecast API and Time bank API.
+      description: Synchronizes time entries from Forecast API and Time bank API.
+      tags:
+        - Synchronize
+      parameters:
+        - name: personId
+          required: false
+          in: query
+          description: Filter by persons unique ID
+          schema:
+            type: integer
+            format: int32
+        - name: before
+          required: false
+          in: query
+          description: Retrieve time entries before given date.
+          schema:
+            type: string
+            format: date
+        - name: after
+          required: false
+          in: query
+          description: Retrieve time entries after given date.
+          schema:
+            type: string
+            format: date
+        - name: vacation
+          required: false
+          in: query
+          description: Filter vacations
+          schema:
+            type: boolean
+      responses:
+        "204":
+          description: Synchronizes time entries from Forecast API and Time bank API.
+        "default":
+          description: Invalid request was sent to the server.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
   /v1/persons/{personId}/total:
     get:
       operationId: listPersonTotalTime
@@ -302,14 +340,14 @@ paths:
         - name: before
           required: false
           in: query
-          description: Last day that timeEntrys will be included format yyyy-mm-dd
+          description: Retrieve time entries before given date.
           schema:
             type: string
             format: date
         - name: after
           required: false
           in: query
-          description: First day that timeEntrys will be included format yyyy-mm-dd
+          description: Retrieve time entries after given date.
           schema:
             type: string
             format: date


### PR DESCRIPTION
When time registration is deleted from Forecast corresponding time entry should be deleted from Timebank aswell.

-Forecast api has a deleted endpoint
-The forecast webhook_subscriptions endpoint may be useful- this could trigger an event on delete which will provide the time entry id.
-Cross referencing forecast response with timebank time entries
-Testing
-Quarkus scheduler

resolves #10 